### PR TITLE
hubconf: add timm to dependencies and import the model lazily

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ DOFA supports input images with any number of channels using our pre-trained fou
 
 ### Using `torch.hub` to Load the DOFA ViT Base Model
 
-This snippet demonstrates how to load a ViT model—specifically, **DOFA ViT Base**—from a GitHub repository that includes a `hubconf.py` entrypoint. The model weights are hosted on Hugging Face via a direct download URL, so **no additional dependencies** beyond PyTorch are required.
+This snippet demonstrates how to load a ViT model—specifically, **DOFA ViT Base**—from a GitHub repository that includes a `hubconf.py` entrypoint. The model weights are hosted on Hugging Face via a direct download URL. The Torch Hub entrypoint requires PyTorch and `timm`, so install the tested version first with `pip install timm==0.9.2`.
 
 ```python
 import torch

--- a/hubconf.py
+++ b/hubconf.py
@@ -2,11 +2,14 @@ MODEL = "https://huggingface.co/earthflow/DOFA/resolve/main/DOFA_ViT_base_e100.p
 
 # hubconf.py
 
-dependencies = ["torch"]
+dependencies = ["torch", "timm"]
 import torch
-from dofa_v1 import vit_base_patch16
 
 def vit_base_dofa(pretrained=True, strict=False, **kwargs):
+    # Import inside the entrypoint so Torch Hub can report a missing dependency
+    # before this timm-dependent import runs.
+    from dofa_v1 import vit_base_patch16
+
     model = vit_base_patch16(**kwargs)
 
     if pretrained:


### PR DESCRIPTION
`hubconf.py` declares only `torch` in `dependencies`, but the model (`dofa_v1.py`) imports `timm`. This declares `timm` and improves the error Torch Hub reports.

torch.hub imports `hubconf.py` to read `dependencies` and only then runs its check (torch/hub.py: `_load_local` -> `_check_dependencies`). So a top-level import of a timm-dependent module raises a deep ImportError before Hub can report the missing package. Moving the model import into the entrypoint lets Hub print a clear `Missing dependencies: timm`.

Note: Torch Hub's `dependencies` does not install anything; it only checks whether the package is importable. So this does not make a torch-only install succeed on its own. It reports the missing package clearly, and the README now points users to `pip install timm==0.9.2` (the version the repo pins).

Tested with `source="local"`:
- torch only: `torch.hub.load(".", "vit_base_dofa", source="local", pretrained=False)` raises `RuntimeError: Missing dependencies: timm` (before this change it was a deep `ModuleNotFoundError: No module named 'timm'`).
- torch + timm==0.9.2: loads and runs a forward pass.

Test environment: Python 3.12.3, torch 2.6.0+cpu, torchvision 0.21.0+cpu, timm 0.9.2 (the pinned version).

The unused `pdb`/`numpy` imports are a separate cleanup PR (#32); the checkpoint pinning is #33.