### PR TITLE
cleanup: remove unused imports (pdb, numpy)

### DIFF
--- a/dofa_v1.py
+++ b/dofa_v1.py
@@ -14,11 +14,9 @@ from wave_dynamic_layer import Dynamic_MLP_OFA
 from operator import mul
 from torch.nn.modules.utils import _pair
 from torch.nn import Conv2d, Dropout
-import numpy as np
 
 import torch
 import torch.nn as nn
-import pdb
 import math
 from functools import reduce
 import json

--- a/wave_dynamic_layer.py
+++ b/wave_dynamic_layer.py
@@ -1,4 +1,3 @@
-import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F


### PR DESCRIPTION
`dofa_v1.py` imports `pdb` and `numpy` but uses neither, and `wave_dynamic_layer.py` imports `numpy` without using it. This removes the three unused imports. No behavior change.